### PR TITLE
fix(deployment): add prisma generate to build and postinstall scripts…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "prisma generate && next build --turbopack",
     "start": "next start",
+    "postinstall": "prisma generate",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
This pull request updates the build and install process to ensure Prisma client code is generated before running or building the application.

Build and install process improvements:

* Updated the `build` script in `package.json` to run `prisma generate` before `next build`, ensuring Prisma client is generated during builds.
* Added a `postinstall` script to `package.json` to automatically run `prisma generate` after dependencies are installed, keeping Prisma client code up to date.… for Vercel